### PR TITLE
Non admin backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ See the [`exports`](/exports) file for an example, which can directly be used wi
 | `OPENSHIFT_BACKUP_CAPACITY`  | `2Gi`              | Create a PersistentVolumeClaim with this size and use it to store the backups. |
 | `OPENSHIFT_BACKUP_SCHEDULE`  | `15 0 * * *`       | The schedule at which the backup CronJob will be run.                          |
 
+## Templates
+
+| Filename                   | Description                                                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `template.yml`             | Backup CronJob which runs on cluster-reader and "custom" cluster-secret-reader (Cluster)Roles.                                                   |
+| `template-no-secret.yml`   | Same as `template.yml` but does not backup secrets.                                                                                              |
+| `template-non-admin-*.yml` | Backup CronJob which can be run as non cluster-reader/cluster-admin User. Must have `edit` permissions to the projects that should be backed up. |
+
 ## Set the timer
 ```
 $ make

--- a/openshift/template-no-secret.yml
+++ b/openshift/template-no-secret.yml
@@ -40,7 +40,7 @@ objects:
     labels:
       app: ${NAME}
 - kind: ClusterRoleBinding
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-cluster-reader
     namespace: ${NAMESPACE}

--- a/openshift/template-non-admin-binding.yml
+++ b/openshift/template-non-admin-binding.yml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: openshift-backup-app-no-admin-binding-template
+message: |-
+  A recurring backup job has been created.
+  For more information on using this template, see https://github.com/gerald1248/openshift-backup
+metadata:
+  name: openshift-backup-app-no-admin-binding-template
+  annotations:
+    description: |-
+      OpenShift cluster backup based on 'oc' and the experimental 2nd day operations backup script (non-admin).
+parameters:
+- name: NAME
+  displayName: Name
+  description: Name of each API object
+  value: openshift-backup
+- name: BACKUP_NAMESPACE
+  displayName: Namespace name
+  description: Name of the namespace/project in which the openshift-backup Job resides in.
+- name: SCHEDULE
+  displayName: Schedule
+  description: Schedule determining when and how often tests are run
+  value: "15 0 * * *"
+- name: CAPACITY
+  displayName: Persistent volume capacity
+  description: Create a PersistentVolumeClaim with this size and use it to store the backups.
+  value: "2Gi"
+- name: BACKUP_RETAIN_DAYS
+  displayName: Backup retain backups (days)
+  description: How many days backups should be retained.
+  value: "7"
+objects:
+- kind: Role
+  apiVersion: v1
+  metadata:
+    name: ${NAME}-secret-reader
+  rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+- kind: RoleBinding
+  apiVersion: v1
+  metadata:
+    name: ${NAME}-secret-reader
+    labels:
+      app: ${NAME}
+  roleRef:
+    kind: Role
+    name: ${NAME}-secret-reader
+  subjects:
+  - kind: ServiceAccount
+    name: ${NAME}
+  userNames:
+  - "system:serviceaccount:${BACKUP_NAMESPACE}:${NAME}"
+- kind: RoleBinding
+  apiVersion: v1
+  metadata:
+    name: ${NAME}-project-reader
+    labels:
+      app: ${NAME}
+  roleRef:
+    kind: ClusterRole
+    name: view
+  subjects:
+  - kind: ServiceAccount
+    name: ${NAME}
+  userNames:
+  - "system:serviceaccount:${BACKUP_NAMESPACE}:${NAME}"

--- a/openshift/template-non-admin-binding.yml
+++ b/openshift/template-non-admin-binding.yml
@@ -32,7 +32,7 @@ parameters:
   value: "7"
 objects:
 - kind: Role
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-secret-reader
   rules:
@@ -40,7 +40,7 @@ objects:
     resources: ["secrets"]
     verbs: ["get", "list"]
 - kind: RoleBinding
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-secret-reader
     labels:
@@ -54,7 +54,7 @@ objects:
   userNames:
   - "system:serviceaccount:${BACKUP_NAMESPACE}:${NAME}"
 - kind: RoleBinding
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-project-reader
     labels:

--- a/openshift/template-non-admin-job.yml
+++ b/openshift/template-non-admin-job.yml
@@ -1,31 +1,28 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: openshift-backup-app-no-secret-template
+  template: openshift-backup-app-no-admin-job-template
 message: |-
   A recurring backup job has been created.
   For more information on using this template, see https://github.com/gerald1248/openshift-backup
 metadata:
-  name: openshift-backup-app-no-secret-template
+  name: openshift-backup-app-no-admin-job-template
   annotations:
     description: |-
-      OpenShift cluster backup based on 'oc' and the experimental 2nd day operations backup script (no secret).
+      OpenShift cluster backup based on 'oc' and the experimental 2nd day operations backup script (non-admin).
+      This is just the job, you need to use the binding version to "bind" it to the projects you want backed up.
 parameters:
 - name: NAME
   displayName: Name
   description: Name of each API object
   value: openshift-backup
-- name: NAMESPACE
-  displayName: Project
-  description: The project that is created for the test runner
-  value: cluster-backup
 - name: SCHEDULE
   displayName: Schedule
   description: Schedule determining when and how often tests are run
   value: "15 0 * * *"
 - name: CAPACITY
   displayName: Persistent volume capacity
-  description: Attempt to bind to this persistent volume
+  description: Create a PersistentVolumeClaim with this size and use it to store the backups.
   value: "2Gi"
 - name: BACKUP_RETAIN_DAYS
   displayName: Backup retain backups (days)
@@ -36,24 +33,8 @@ objects:
   apiVersion: v1
   metadata:
     name: ${NAME}
-    namespace: ${NAMESPACE}
     labels:
       app: ${NAME}
-- kind: ClusterRoleBinding
-  apiVersion: v1
-  metadata:
-    name: ${NAME}-cluster-reader
-    namespace: ${NAMESPACE}
-    labels:
-      app: ${NAME}
-  roleRef:
-    kind: ClusterRole
-    name: cluster-reader
-  subjects:
-  - kind: ServiceAccount
-    name: ${NAME}
-  userNames:
-  - "system:serviceaccount:${NAMESPACE}:${NAME}"
 - kind: PersistentVolumeClaim
   apiVersion: v1
   metadata:
@@ -70,7 +51,6 @@ objects:
   apiVersion: v1
   metadata:
     name: ${NAME}
-    namespace: ${NAMESPACE}
     labels:
       app: ${NAME}
   spec:
@@ -99,10 +79,12 @@ objects:
               cpu: 100m
               memory: 512Mi
           env:
+          - name: POD_NAMESPACE
+            value: ${NAMESPACE}
           - name: OPENSHIFT_BACKUP_RETAIN_DAYS
             value: ${BACKUP_RETAIN_DAYS}
           - name: BACKUP_SECRETS
-            value: "false"
+            value: ${BACKUP_SECRETS}
           volumeMounts:
           - name: ${NAME}-data
             mountPath: /openshift-backup
@@ -114,7 +96,6 @@ objects:
   kind: CronJob
   metadata:
     name: ${NAME}
-    namespace: ${NAMESPACE}
     labels:
       app: ${NAME}
   spec:
@@ -142,8 +123,6 @@ objects:
               - -c
               - openshift-backup
               env:
-              - name: POD_NAMESPACE
-                value: ${NAMESPACE}
               - name: OPENSHIFT_BACKUP_RETAIN_DAYS
                 value: ${BACKUP_RETAIN_DAYS}
               volumeMounts:
@@ -154,33 +133,3 @@ objects:
               persistentVolumeClaim:
                 claimName: ${NAME}
             restartPolicy: Never
-- kind: LimitRange
-  apiVersion: v1
-  metadata:
-    name: ${NAME}
-    namespace: ${NAMESPACE}
-    labels:
-      app: ${NAME}
-  spec:
-    limits:
-    - type: Container
-      default:
-        cpu: 400m
-        memory: 1Gi
-      defaultRequest:
-        cpu: 200m
-        memory: 512Mi
-- kind: ResourceQuota
-  apiVersion: v1
-  metadata:
-    name: ${NAME}
-    namespace: ${NAMESPACE}
-    labels:
-      app: ${NAME}
-  spec:
-    hard:
-      pods: "4"
-      requests.cpu: 800m
-      requests.memory: 2Gi
-      limits.cpu: 1600m
-      limits.memory: 4Gi

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -9,7 +9,7 @@ metadata:
   name: openshift-backup-app-template
   annotations:
     description: |-
-      OpenShift cluster backup based on 'oc' and the experimental 2nd day operations backup script
+      OpenShift cluster backup based on 'oc' and the experimental 2nd day operations backup script (with secrets).
 parameters:
 - name: NAME
   displayName: Name
@@ -123,8 +123,6 @@ objects:
               cpu: 100m
               memory: 512Mi
           env:
-          - name: POD_NAMESPACE
-            value: ${NAMESPACE}
           - name: OPENSHIFT_BACKUP_RETAIN_DAYS
             value: ${BACKUP_RETAIN_DAYS}
           - name: BACKUP_SECRETS

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -40,7 +40,7 @@ objects:
     labels:
       app: ${NAME}
 - kind: ClusterRole
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-secret-reader
   rules:
@@ -48,7 +48,7 @@ objects:
     resources: ["secrets"]
     verbs: ["get", "list"]
 - kind: ClusterRoleBinding
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-secret-reader
     namespace: ${NAMESPACE}
@@ -63,7 +63,7 @@ objects:
   userNames:
   - "system:serviceaccount:${NAMESPACE}:${NAME}"
 - kind: ClusterRoleBinding
-  apiVersion: v1
+  apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     name: ${NAME}-cluster-reader
     namespace: ${NAMESPACE}


### PR DESCRIPTION
These two new templates allow a "developer" user to create the CronJob in one of his namespaces and then simply create the "binding" template on all namespaces he wants to have backed up.

There seems to be an ordering issue with OpenShift templates, as I wrote you on Slack, though it seems that as long as it just complains about the Role not being found, it still creates everything that is needed correctly.

Let me know if that is okay, to merge because of this creation ordering issue.

Fixes #3.