### PR TITLE
Remove unused OpenShift template vars from non admin binding

### DIFF
--- a/openshift/template-no-secret.yml
+++ b/openshift/template-no-secret.yml
@@ -143,7 +143,9 @@ objects:
               - openshift-backup
               env:
               - name: POD_NAMESPACE
-                value: ${NAMESPACE}
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: OPENSHIFT_BACKUP_RETAIN_DAYS
                 value: ${BACKUP_RETAIN_DAYS}
               volumeMounts:

--- a/openshift/template-non-admin-binding.yml
+++ b/openshift/template-non-admin-binding.yml
@@ -16,20 +16,8 @@ parameters:
   description: Name of each API object
   value: openshift-backup
 - name: BACKUP_NAMESPACE
-  displayName: Namespace name
+  displayName: Backup Job Namespace
   description: Name of the namespace/project in which the openshift-backup Job resides in.
-- name: SCHEDULE
-  displayName: Schedule
-  description: Schedule determining when and how often tests are run
-  value: "15 0 * * *"
-- name: CAPACITY
-  displayName: Persistent volume capacity
-  description: Create a PersistentVolumeClaim with this size and use it to store the backups.
-  value: "2Gi"
-- name: BACKUP_RETAIN_DAYS
-  displayName: Backup retain backups (days)
-  description: How many days backups should be retained.
-  value: "7"
 objects:
 - kind: Role
   apiVersion: authorization.openshift.io/v1

--- a/openshift/template-non-admin-job.yml
+++ b/openshift/template-non-admin-job.yml
@@ -84,7 +84,9 @@ objects:
               memory: 512Mi
           env:
           - name: POD_NAMESPACE
-            value: ${NAMESPACE}
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: OPENSHIFT_BACKUP_RETAIN_DAYS
             value: ${BACKUP_RETAIN_DAYS}
           - name: BACKUP_SECRETS

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -171,7 +171,9 @@ objects:
               - openshift-backup
               env:
               - name: POD_NAMESPACE
-                value: ${NAMESPACE}
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: OPENSHIFT_BACKUP_RETAIN_DAYS
                 value: ${BACKUP_RETAIN_DAYS}
               volumeMounts:


### PR DESCRIPTION
This removes unused OpenShift template vars from the non-admin binding template.