### PR TITLE
Workaround for CronJob API/oc client mapping problem

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -18,6 +18,6 @@ if [ ! ${BACKUP_SECRETS} ]; then
     TEMPLATE_FILE="openshift/template-no-secret.yml"
 fi
 
-oc new-app --file="${TEMPLATE_FILE}" --param='NAME'="${OPENSHIFT_BACKUP_NAME}" --param='NAMESPACE'="${OPENSHIFT_BACKUP_NAMESPACE}" --param='CAPACITY'="${OPENSHIFT_BACKUP_CAPACITY}" --param='SCHEDULE'="${OPENSHIFT_BACKUP_SCHEDULE}"
+oc process -f "${TEMPLATE_FILE}" --param='NAME'="${OPENSHIFT_BACKUP_NAME}" --param='NAMESPACE'="${OPENSHIFT_BACKUP_NAMESPACE}" --param='CAPACITY'="${OPENSHIFT_BACKUP_CAPACITY}" --param='SCHEDULE'="${OPENSHIFT_BACKUP_SCHEDULE}" | oc apply -f -
 
 oc get all


### PR DESCRIPTION
Swapped `oc create -f` for `oc process -f` piped to `oc create -f -`.

This is a workaround to address a client mapping problem for the CronJob api version introduced in OpenShift 3.11.  See: https://github.com/openshift/origin/issues/21789

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>